### PR TITLE
Topic tbg defaults extent

### DIFF
--- a/src/tools/bin/egetopt
+++ b/src/tools/bin/egetopt
@@ -24,7 +24,7 @@ help()
 {
     echo "egetopt (extended getopt)"
     echo ""
-    echo "extent the program getopt to support more syntax"
+    echo "extend the program getopt to support a different syntax for optional arguments"
     echo "allow argument assignment with space between option and argument"
     echo ""
     echo "usage: egetopt [-h] [getopt_ARGUMENTS] ++ parameters"
@@ -32,8 +32,9 @@ help()
     echo "-h | --help                    - Shows help (this output)."
     echo " "
     echo "ATTENTION:" 
-    echo "    - If you use optional arguments the result is only valid" 
-    echo "      when you allow minimum one non option argument"
+    echo "    - if you require at least one non-option argument (an argument not" 
+    echo "      starting with - or --) the result is only valid when you allow"
+    echo "      minimum one non-option argument"
     echo "    - If more than one non option argument is given and the last"
     echo "      option has an optional argument the argument is assigned to"
     echo "      the option" 
@@ -43,7 +44,7 @@ help()
     echo ""
     echo "NOT SUPPORTED:"
     echo '    - begin an option with `+`'
-    echo "    - abbreviation of long options"
+    echo '    - abbreviations of getopt `longoptions`'
     echo ""
     echo ""
     echo 'output of `getopt` help:'

--- a/src/tools/bin/egetopt
+++ b/src/tools/bin/egetopt
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# Copyright 2014 Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+help()
+{
+    echo "egetopt (extended getopt)"
+    echo ""
+    echo "extent the program getopt to support more syntax"
+    echo "allow argument assignment with space between option and argument"
+    echo ""
+    echo "usage: egetopt [-h] [getopt_ARGUMENTS] ++ parameters"
+    echo ""
+    echo "-h | --help                    - Shows help (this output)."
+    echo " "
+    echo "ATTENTION:" 
+    echo "    - If you use optional arguments the result is only valid" 
+    echo "      when you allow minimum one non option argument"
+    echo "    - If more than one non option argument is given and the last"
+    echo "      option has an optional argument the argument is assigned to"
+    echo "      the option" 
+    echo "      e.g. --foo has an optional argument"
+    echo "           --foo ALICE BOB  is the same as --foo=ALICE BOB"
+    echo "           BOB --foo ALICE  is the same as BOB --foo=ALICE"
+    echo ""
+    echo "NOT SUPPORTED:"
+    echo "    - space between optional argument and option"
+    echo '    - begin an option with `+`'
+    echo "    - abbreviation of long options"
+    echo ""
+    echo ""
+    echo 'output of `getopt` help:'
+    getopt -h 2>&1
+}
+
+# arguments for getopt
+egetOptArgs=`echo $* | sed 's/++.*$//g'`
+# user arguments
+userArgs=`echo $* | sed 's/^.*++//g'`
+ 
+# evaluate options for getopt 
+OPTS=`getopt -o o:l:n:qhV -l help,options:,longoptions:version -- $egetOptArgs`
+eval set -- "$OPTS"
+
+shortDef=""
+longDef=""
+getOptArgs=""
+while true ; do
+    case "$1" in
+        -o)
+            shortDef="$2"
+            getOptArgs+=" $1 $2"
+            shift
+            ;;
+        -l)
+            longDef="$2"
+            getOptArgs+=" $1 $2"
+            shift
+            ;;
+        -h|--help)
+            # overwrite `getopt` help
+            echo -e "$(help)"
+            shift
+            exit 1
+            ;;
+        --) 
+            shift
+            break
+            ;;
+        *)
+            getOptArgs+=" $1"
+            ;;
+    esac
+    shift
+done
+
+# begin the transform the user arguments
+# -- is appended to define the end of the arguments
+eval set -- "$userArgs --"
+
+# nonOptionCheck is only important if the last options were scanned
+# e.g. -s has optional argument
+# 
+# transform: `-s foo NONOPTION --`, `-s foo -f foo [...] --`
+# not transform: `-s NONOPTION --`
+#
+# if nenOptionCheck is set to 3 it is possible to transform
+# `NONOPTION -s foo`
+#   
+nonOptionCheck=4
+transformedArgs="" 
+
+disableCecks=""
+while true ; do
+    case "$1" in
+        --) 
+            shift 
+            break
+            ;;
+        *)
+            transformedArgs+=" $1"
+            if [ -z $disableCecks ] ; then
+                # transform short option if no argument is directly appended
+                if [[ $1 =~ ^-.?$ ]] && [[ ! $2 =~ ^- ]] ; then
+                    theShortOpt=`echo $1 | tr -d "-"`
+                    if [ $# -ge $nonOptionCheck ] && [[ $shortDef =~ $theShortOpt: ]] ; then
+                        # append argument to option
+                        transformedArgs+="$2"
+                        shift
+                    fi
+                # transform long option if no argument with `=` is set
+                elif [[ $1 =~ ^-- ]] && [[ ! $1 =~ .*=.* ]] && [[ ! $2 =~ ^- ]] ; then
+                    theLongOpt=`echo $1 | sed 's/--//g'`
+                    if [ $# -ge $nonOptionCheck ] && [[ $longDef =~ $theLongOpt: ]] ; then
+                        # append argument to option
+                        transformedArgs+="=$2"
+                        shift
+                    fi
+                elif [[ ! $1 =~ ^-- ]] && [[ ! $1 =~ ^-.*$ ]] ; then 
+                    if [ -z "$POSIXLY_CORRECT" ] ; then
+                        if [ $nonOptionCheck -eq 4 ] ; then
+                            nonOptionCheck=3
+                        fi
+                    else
+                        disableCecks="true"
+                    fi
+                fi
+            fi 
+            ;;
+    esac
+    shift
+done    
+
+getopt $getOptArgs -- $transformedArgs

--- a/src/tools/bin/egetopt
+++ b/src/tools/bin/egetopt
@@ -42,7 +42,6 @@ help()
     echo "           BOB --foo ALICE  is the same as BOB --foo=ALICE"
     echo ""
     echo "NOT SUPPORTED:"
-    echo "    - space between optional argument and option"
     echo '    - begin an option with `+`'
     echo "    - abbreviation of long options"
     echo ""

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -160,12 +160,12 @@ help()
     echo "TBG (template batch generator)"
     echo "create a new folder for a batch job and copy in all important files"
     echo ""
-    echo "usage: tbg -c cfgFile [-s submitsystem] [-t templateFile] [-p project] [-o \"VARNAME1=10 VARNAME2=5\"] [-h] destinationPath"
+    echo "usage: tbg -c cfgFile [-s [submitsystem]] [-t [templateFile]] [-p project] [-o \"VARNAME1=10 VARNAME2=5\"] [-h] destinationPath"
     echo ""
     echo "-c | --cfg      file           - Configuration file to set up batch file."
-    echo "-s | --submit   command        - Submit command (qsub, \"qsub -h\", sbatch, ...)"
+    echo "-s | --submit   [command]      - Submit command (qsub, \"qsub -h\", sbatch, ...)"
     echo "                                 Default: via export TBG_SUBMIT"
-    echo "-t | --tpl      file           - Template to create a batch file from."
+    echo "-t | --tpl      [file]         - Template to create a batch file from."
     echo "                                 tbg will use stdin, if no file is specified."
     echo "                                 Default: via export TBG_TPLFILE"
     echo "-p | --project  folder         - Project folder containing sourcecode and binaries"
@@ -190,8 +190,23 @@ help()
 initCall="$0 $*"
 projectPath="."
 
-# options may be followed by one colon to indicate they have a required argument
-OPTS=`getopt -o p:t:c:s:o:h -l project:,tpl:,cfg:,submit:,help -- "$@"`
+pathToegetopt=`which egetopt`
+if [ $? -eq 0 ] ; then
+    pathToegetopt=`dirname $pathToegetopt`
+else
+    pathToegetopt=`dirname $0`
+fi
+
+egetoptTool=`which $pathToegetopt/egetopt`
+if [ $? -ne 0 ] ; then
+    echo "Can't find program egetopt" >&2
+    exit
+fi
+
+# options may be followed by 
+# - one colon to indicate they have a required argument
+# - two colon to indicate they have a optional argument
+OPTS=`$egetoptTool -o p:t::c:s::o:h -l project:,tpl::,cfg:,submit::,help -n tbg ++ "$@"`
 if [ $? != 0 ] ; then
     # something went wrong, getopt will put out an error message for us
     exit 1
@@ -199,17 +214,11 @@ fi
 
 eval set -- "$OPTS"
 
-# default parameters from environment variables (e.g. in a .profile file)
-#   -s | --submit
-submit_command=${TBG_SUBMIT:-""}
-#   -t | --tpl
-tooltpl_file=${TBG_TPLFILE:-""}
-
 # parser
 while true ; do
     case "$1" in
         -s|--submit)
-            submit_command="$2"
+            submit_command=${2:-$TBG_SUBMIT}
             shift
             ;;
        -p|--project)
@@ -225,7 +234,7 @@ while true ; do
             shift
             ;;
        -t|--tpl)
-            tooltpl_file="$2"
+            tooltpl_file=${2:-$TBG_TPLFILE}
             shift
             ;;
         -h|--help)

--- a/src/tools/bin/tbg
+++ b/src/tools/bin/tbg
@@ -164,10 +164,10 @@ help()
     echo ""
     echo "-c | --cfg      file           - Configuration file to set up batch file."
     echo "-s | --submit   [command]      - Submit command (qsub, \"qsub -h\", sbatch, ...)"
-    echo "                                 Default: via export TBG_SUBMIT"
+    echo "                                 Default: [submitsystem] via export TBG_SUBMIT"
     echo "-t | --tpl      [file]         - Template to create a batch file from."
     echo "                                 tbg will use stdin, if no file is specified."
-    echo "                                 Default: via export TBG_TPLFILE"
+    echo "                                 Default: [templateFile] via export TBG_TPLFILE"
     echo "-p | --project  folder         - Project folder containing sourcecode and binaries"
     echo "                                 Default: current directory"
     echo "-o                             - Overwrite any template variable:"
@@ -200,15 +200,15 @@ fi
 egetoptTool=`which $pathToegetopt/egetopt`
 if [ $? -ne 0 ] ; then
     echo "Can't find program egetopt" >&2
-    exit
+    exit 1
 fi
 
 # options may be followed by 
-# - one colon to indicate they have a required argument
-# - two colon to indicate they have a optional argument
+# - one colon to indicate they has a required argument
+# - two colons to indicate they has a optional argument
 OPTS=`$egetoptTool -o p:t::c:s::o:h -l project:,tpl::,cfg:,submit::,help -n tbg ++ "$@"`
 if [ $? != 0 ] ; then
-    # something went wrong, getopt will put out an error message for us
+    # something went wrong, egetopt will put out an error message for us
     exit 1
 fi
 
@@ -219,6 +219,10 @@ while true ; do
     case "$1" in
         -s|--submit)
             submit_command=${2:-$TBG_SUBMIT}
+            if [ -z "$submit_command" ] ; then
+                echo "missing submit command for -s|--submit" >&2
+                exit 1
+            fi
             shift
             ;;
        -p|--project)


### PR DESCRIPTION
In relation of my suggestion in #613 this pull request allow to use optional arguments for options without the syntax restriction of `getopt`

e.g:
`tbg -s -t k20.tpl -c path/config.cfg JOB_FOLDER` -> check environment variable `TBG_SUBMIT` to find the submit command
and
`tbg -s qsub -t k20.tpl -c path/config.cfg JOB_FOLDER` -> use the submit command `qsub`
