### PR TITLE
Python parameters: fix as_dict() methods for correct serialization

### DIFF
--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -7,6 +7,7 @@ License: GPLv3+
 """
 
 import numpy as np
+import inspect
 
 
 class Parameter(object):
@@ -68,8 +69,16 @@ class Parameter(object):
         --------
         A dictionary with the member variables as (key, value) pairs.
         """
+        d = dict(
+            cls=type(self).__name__,
+            name=self.name,
+            type=self.type,
+            unit=self.unit,
+            default=self.default,
+            value=self.value,
+            dtype=self.dtype.__name__)
 
-        return self.__dict__
+        return d
 
     def macro_name(self):
         """
@@ -175,8 +184,10 @@ class UiParameter(Parameter):
         """
 
         members = super(UiParameter, self).as_dict()
-        del members["formatter"]
-        del members["dtype"]
+        members["label"] = self.label
+        members["formatter"] = str(inspect.getsourcelines(self.formatter)[
+                                   0]).strip("['\\n']").split(" = ")[1]
+
         return members
 
 


### PR DESCRIPTION
Refactor the `as_dict()` method for both `Parameter` and `UiParameter` class. 
They now no longer use the `__dict__` method since this returns a reference to the members of the objects and by deleting from this dictionary, one effectively removes member-variables from objects.
Instead dictionary creation is done manually.
Now serialization data also includes the lambda for formatting, the label, the class of an object and the dtype as a string.