### PR TITLE
Fix taurus SCS5 setup

### DIFF
--- a/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k20x_picongpu.profile.example
@@ -13,44 +13,47 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
-# General modules #############################################################
+# Modules #####################################################################
 #
-module purge
-module load oscar-modules
-module load cmake/3.10.1
-module load git
-module load cuda/8.0.61 # gcc <= 5, intel 15-16
-module load bullxmpi
-module load gnuplot/4.6.1
+module load modenv/scs5
+module load foss/2018a
+module load GCC/6.4.0-2.28
+module load CMake/3.10.2-GCCcore-6.4.0
+module load CUDA/9.2.88  # gcc <= 7, intel 15-17
+module load OpenMPI/2.1.2-GCC-6.4.0-2.28
 
-# Compilers ###################################################################
-### GCC
-module load gcc/5.3.0
-module load boost/1.64.0-gnu5.3
-### ICC
-#module load intel/2015.3.187 boost/1.59.0-intel2015.3.187
-### PGI
-#export BOOST_ROOT=$HOME/lib/boost_1_57_pgi_14_9
-#export BOOST_INC=$BOOST_ROOT/include
-#export BOOST_LIB=$BOOST_ROOT/lib
-# must be set in $(which <pgiDir>/bin/localrc):
-#   set NOSWITCHERROR=YES;
-#module load pgi/14.9 boost/<noneBuildYet>
+module load git/2.18.0-GCCcore-6.4.0
+module load gnuplot/5.2.4-foss-2018a
 
-# Other Software ##############################################################
-#
-module load hdf5/1.8.18-gcc-5.3.0-xmpi
-module load zlib/1.2.8
+module load Boost/1.66.0-foss-2018a
+# currently not linking correctly:
+#module load HDF5/1.10.1-foss-2018a
+module load zlib/1.2.11-GCCcore-6.4.0
+
+# module system does not expand cmake prefix path:
+export CMAKE_PREFIX_PATH=$EBROOTLIBPNG:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
 
 # Environment #################################################################
 #
-#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
 
-export PNGWRITER_ROOT=$HOME/lib/pngwriter
-export SPLASH_ROOT=$HOME/lib/splash
+# path to own libraries:
+export ownLibs=$HOME
+# workaround HDF5:
+export HDF5_ROOT=$ownLibs/lib/hdf5
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$HDF5_ROOT:$CMAKE_PREFIX_PATH
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
+# pngwriter needs to be build by the user:
+export PNGwriter_DIR=$ownLibs/lib/pngwriter
+export CMAKE_PREFIX_PATH=$PNGwriter_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib/
+
+# splash needs to be build by the user:
+export Splash_DIR=$ownLibs/lib/splashModule2
+export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib/
+
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
@@ -64,6 +67,6 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
-#   - "gpu1" queue
+#   - "gpu2" queue
 export TBG_SUBMIT="sbatch"
-export TBG_TPLFILE="etc/picongpu/taurus-tud/k20x.tpl"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/k20.tpl"

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -26,16 +26,35 @@ module load git/2.18.0-GCCcore-6.4.0
 module load gnuplot/5.2.4-foss-2018a
 
 module load Boost/1.66.0-foss-2018a
-module load HDF5/1.10.1-foss-2018a
+# currently not linking correctly:
+#module load HDF5/1.10.1-foss-2018a
 module load zlib/1.2.11-GCCcore-6.4.0
+
+# module system does not expand cmake prefix path:
+export CMAKE_PREFIX_PATH=$EBROOTLIBPNG:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
 
 # Environment #################################################################
 #
-export PNGWRITER_ROOT=$HOME/lib/pngwriter
-export SPLASH_ROOT=$HOME/lib/splash
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/pngwriter/lib/
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/lib/splash/lib/
+# path to own libraries:
+export ownLibs=$HOME
+
+# workaround HDF5:
+export HDF5_ROOT=$ownLibs/lib/hdf5
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$HDF5_ROOT:$CMAKE_PREFIX_PATH
+
+# pngwriter needs to be build by the user:
+export PNGwriter_DIR=$ownLibs/lib/pngwriter
+export CMAKE_PREFIX_PATH=$PNGwriter_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib/
+
+# splash needs to be build by the user:
+export Splash_DIR=$ownLibs/lib/splashModule2
+export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib/
+
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples

--- a/etc/picongpu/taurus-tud/knl_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/knl_picongpu.profile.example
@@ -13,21 +13,37 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
 #export EDITOR="nano"
 
-# General modules #############################################################
+# Modules #############################################################
 #
 module purge
-module load cmake/3.10.1
-module load git
-module load intelmpi/2017.2.174
+module load modenv/scs5
+module load iimpi/2018a
+module load git/2.18.0-GCCcore-6.4.0
+module load CMake/3.11.4-GCCcore-7.3.0
+module load Boost/1.66.0-intel-2018a
+module load HDF5/1.10.1-intel-2018a
+module load libpng/1.6.34-GCCcore-7.3.0
 
-# Compilers ###################################################################
-### ICC
-module load intel/2017.2.174
-# Boost needs to be build by yourself for now!
-# The boost root path needs to be adjusted.
-export BOOST_ROOT=$HOME/lib/boost-1.62.0
-export LD_LIBRARY_PATH=$BOOST_ROOT:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+# module system does not expand cmake prefix path:
+export CMAKE_PREFIX_PATH=$EBROOTLIBPNG:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$EBROOTZLIB:$CMAKE_PREFIX_PATH
+
+# Environment ###################################################################
+#
+
+# compilers are not set correctly by the module system:
+export CC=`which icc`
+export CXX=$CC
+
+export ownLibs=$HOME
+
+export PNGwriter_DIR=$ownLibs/lib/pngwriter
+export CMAKE_PREFIX_PATH=$PNGwriter_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PNGwriter_DIR/lib/
+
+export Splash_DIR=$ownLibs/lib/splash
+export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Splash_DIR/lib/
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples


### PR DESCRIPTION
This pull request fixes all compile issues with the current SCS5 setup at taurs ZIH.
It provides several workaround:
 - define `CMAKE_PREFIX_PATH` for zlib and pngwriter
 - use own hdf5 (due to linking error with gcc)

Compile test were all successful. 
Run time test are pending for knl and k80 and were successful for k20x.

`*.tpl`files did not need an update. 