### PR TITLE
Crate ENTRYPOINT wrapper that forces login shell

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
@@ -62,13 +62,19 @@ RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
                         "spack load $PIC_PACKAGE\n" \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpirun { $(which mpirun) --allow-run-as-root $@; }\n' \
+                        '   export -f mpirun\n' \
                         'fi\n' \
-                        'export -f mpirun\n' \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpiexec { $(which mpiexec) --allow-run-as-root $@; }\n' \
+                        '   export -f mpiexec\n' \
                         'fi\n' \
-                        'export -f mpiexec\n' \
                > /etc/profile.d/picongpu.sh
+
+# force the use of a login shell
+RUN        /bin/echo -e '#!/bin/bash -l\n' \
+                        'exec "$@"\n' \
+               > /etc/entrypoint.sh
+RUN        chmod a+x /etc/entrypoint.sh
 
 # build example for out-of-the-box usage: LWFA
 RUN        /bin/bash -l -c ' \
@@ -105,4 +111,6 @@ COPY       start_khi_4.sh /usr/bin/bench4
 COPY       start_khi_8.sh /usr/bin/bench8
 COPY       start_foil_4.sh /usr/bin/foil4
 COPY       start_foil_8.sh /usr/bin/foil8
-CMD        /bin/bash -l
+
+ENTRYPOINT ["/etc/entrypoint.sh"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
`CMD` will be overridden if a user provided command to `docker/singularity run` is supplied. This causes an uninitialized environment in some situations(e.g. running under Singularity). Here an `ENTRYPOINT` wrapper is provided which forces a login shell under `docker/singularity run` regardless of if the user supplies a command. `CMD` is also provided so that Singularity behavior more closely mirrors that of Docker if the user does not provide a command.

`mpirun`/`mpiexec` aliases are also moved within the conditional block so that a warning message isn't printed when running as a non root user.